### PR TITLE
Change timeout, thread joining.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="supervisor-quick",
-    version="0.1.3",
+    version="0.1.4",
     description="Bypass supervisor's nasty callbacks stack and make it quick!",
     author="Lx Yu",
     author_email="i@lxyu.net",

--- a/supervisor_quick.py
+++ b/supervisor_quick.py
@@ -63,7 +63,7 @@ class QuickControllerPlugin(ControllerPluginBase):
             threads.append(t)
 
         for t in threads:
-            t.join(3)
+            t.join()
 
     def do_quickstop(self, arg):
         self._quick_do(arg, command='stop')

--- a/supervisor_quick.py
+++ b/supervisor_quick.py
@@ -9,7 +9,7 @@ from supervisor.supervisorctl import ControllerPluginBase
 class QuickControllerPlugin(ControllerPluginBase):
     name = "quick"
 
-    def __init__(self, controller, retries=30, **config):
+    def __init__(self, controller, retries=600, **config):
         self.ctl = controller
         self.retries = retries
 


### PR DESCRIPTION
1. timeout set to 1min. (further discussion?)
2. all threads should be joined before quitting. Eg, in `quickrestart`, if call to `stop` exits before it times out, the actual `start` may called when process are `STOPPING`, and causes the process not to start.
